### PR TITLE
Cleanup output from backing up contrib directories

### DIFF
--- a/tmp/scripts/rebuild.sh
+++ b/tmp/scripts/rebuild.sh
@@ -15,10 +15,18 @@
 
 DIRS="modules/contrib themes/contrib libraries/contrib"
 for d in $DIRS; do
-  rm -Rf "$d.bak.tar.gz"
-  mv $d "$d.bak"
-  tar cvzf "$d.bak.tar.gz" "$d.bak"
-  rm -Rf "$d.bak"
+  if [ -e "$d.bak.tar.gz" ]
+  then
+    rm -f "$d.bak.tar.gz"
+    echo "Old $d.bak.tar.gz deleted"
+  fi
+  if [ -e "$d" ]
+  then
+    mv "$d" "$d.bak"
+    tar czf "$d.bak.tar.gz" "$d.bak"
+    rm -Rf "$d.bak"
+    echo "Archived $d to $d.bak.tar.gz"
+  fi
 done
 drush make --yes --working-copy --no-core --no-cache --contrib-destination=. contrib.make.yml
 


### PR DESCRIPTION
Porting #12 to 8.x, with the previously suggested changes