### PR TITLE
Travis settings.local.php needs php tag

### DIFF
--- a/tmp/travis_scripts/settings.local.php
+++ b/tmp/travis_scripts/settings.local.php
@@ -1,3 +1,4 @@
+<?php
 /**
  * Local settings configuration.
  */


### PR DESCRIPTION
Since it's a full php file, and not a snippet, it will get interpreted as text without an opening php tag