### PR TITLE
Compile SCSS with production settings by default

### DIFF
--- a/tmp/scripts/build.sh
+++ b/tmp/scripts/build.sh
@@ -83,7 +83,7 @@ do
   if [[ -d $THEME ]]; then
     cd $THEME
     if [ -a config.rb ]; then
-      compass compile
+      compass compile -e production
     fi
   fi
 done


### PR DESCRIPTION
Compiling with production settings renders the CSS in a compact way, and doesn't add all of the comments with selector locations in the SCSS files.

This will result in fewer & smaller changes to the build CSS. 
Drupal strips out CSS comments when aggregating files, but this will result in smaller files if files are not aggregated for any reason.

For local development, running `compass compile` (possibly `--force`, the first time if source files haven' t changed yet) will recreate the CSS files with comments.  Even better, use `compass compile --sourcemap` to allow your browser to load SCSS directly in the inspector. 
(or `watch` instead of `compile` :+1:)